### PR TITLE
adding auth functionality (signin,signup,signout)

### DIFF
--- a/attendnow/src/components/AuthModal.vue
+++ b/attendnow/src/components/AuthModal.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref, watch, computed } from 'vue'
+import { useAuth, signIn, signUp } from '../lib/useAuth'
 
 type Mode = 'signin' | 'signup'
 
@@ -12,17 +13,28 @@ watch(localShow, v => emit('update:show', v))
 
 const isSignin = computed(() => props.mode === 'signin')
 
-// demo state
+// auth state
+const { error, loading } = useAuth()
+
+// form state
 const name = ref('')
 const email = ref('')
 const password = ref('')
 
 function close() { localShow.value = false }
 
-function submit() {
-  // replace with real auth
-  console.log(isSignin.value ? 'Sign in' : 'Sign up', { name: name.value, email: email.value })
-  close()
+async function submit() {
+  try {
+    if (isSignin.value) {
+      await signIn(email.value, password.value)
+    } else {
+      await signUp(name.value, email.value, password.value)
+    }
+    close()
+  } catch (e) {
+    // error message is handled via useAuth().error
+    console.error('[auth] submit error', e)
+  }
 }
 </script>
 
@@ -47,7 +59,10 @@ function submit() {
             <span>Password</span>
             <input v-model="password" type="password" placeholder="••••••••" required />
           </label>
-          <button class="primary" type="submit">{{ isSignin ? 'Sign in' : 'Create account' }}</button>
+          <p v-if="error" class="error">{{ error }}</p>
+          <button class="primary" type="submit" :disabled="loading">
+            {{ loading ? (isSignin ? 'Signing in…' : 'Creating…') : (isSignin ? 'Sign in' : 'Create account') }}
+          </button>
         </form>
       </div>
     </div>
@@ -66,4 +81,6 @@ label { display:flex; flex-direction:column; gap:.25rem; color:#e5e7eb; }
 input { padding:.55rem .65rem; border-radius:8px; background:#0b0d10; border:1px solid rgba(255,255,255,0.12); color:#e5e7eb; }
 .primary { margin-top:.25rem; padding:.6rem .8rem; border:none; border-radius:8px; background:#8ab4ff; color:#0b0d10; font-weight:600; cursor:pointer; }
 .primary:hover { filter:brightness(1.05); }
+.primary:disabled { opacity: .7; cursor: not-allowed; }
+.error { color: #fda4af; margin: .25rem 0 0; font-size: .9rem; }
 </style>

--- a/attendnow/src/components/CourseList.vue
+++ b/attendnow/src/components/CourseList.vue
@@ -1,20 +1,42 @@
 <script setup lang="ts">
-import { ref, onMounted, onUnmounted } from "vue";
+import { ref, onMounted, onUnmounted, watch, computed } from "vue";
 import { listenMyCourses, startCheckIn, endCheckIn, updateCourse, deleteCourse } from "../services/courseService";
 import CourseEditModal from "./CourseEditModal.vue";
-import type { Course } from "../types";
+import CourseStudentsModal from "./CourseStudentsModal.vue";
+import type { Course, Student } from "../types";
+import { useAuth } from "../lib/useAuth";
 
-// TODO: replace this with your real Auth UID once you wire Firebase Auth
-const instructorId = "tjuFeWwFszXemcH6LwNcBwHtnbW2";
+// Use the currently authenticated instructor UID
+const { user, loading: authLoading } = useAuth();
+const instructorId = computed(() => user.value?.uid || "");
 
 const courses = ref<Course[]>([]);
 const showEditModal = ref(false);
 const editingCourse = ref<Course | null>(null);
+const showStudentsModal = ref(false);
+const studentsCourse = ref<Course | null>(null);
 
 let off: (() => void) | null = null;
 
+function resubscribe() {
+  if (off) {
+    off();
+    off = null;
+  }
+  const uid = instructorId.value;
+  if (!uid) {
+    courses.value = [];
+    return;
+  }
+  off = listenMyCourses(uid, (rows) => (courses.value = rows));
+}
+
 onMounted(() => {
-  off = listenMyCourses(instructorId, (rows) => (courses.value = rows));
+  resubscribe();
+});
+
+watch(instructorId, () => {
+  resubscribe();
 });
 
 onUnmounted(() => {
@@ -32,6 +54,11 @@ async function onEnd(id: string) {
 function onEdit(course: Course) {
   editingCourse.value = course;
   showEditModal.value = true;
+}
+
+function onManageStudents(course: Course) {
+  studentsCourse.value = course;
+  showStudentsModal.value = true;
 }
 
 async function onSave(updatedCourse: Course) {
@@ -63,15 +90,27 @@ async function onDelete(course: Course) {
     }
   }
 }
+
+async function onSaveStudents(students: Student[]) {
+  if (!studentsCourse.value) return;
+  try {
+    await updateCourse(studentsCourse.value.id, { students_list: students });
+  } catch (error) {
+    console.error("Error updating students:", error);
+    alert("Failed to update students. Please try again.");
+  }
+}
 </script>
 
 <template>
   <div class="courses">
+    <div v-if="authLoading">Loading your courses…</div>
+    <div v-else-if="!instructorId">Please sign in to view your courses.</div>
     <div v-for="c in courses" :key="c.id" class="course">
       <div class="course-header">
         <div class="course-info">
           <h3>{{ c.name }} ({{ c.code }}) — {{ c.semester }}</h3>
-          <p>Students: {{ c.students.length }}</p>
+          <p>Students: {{ c.students_list.length }}</p>
         </div>
         <div class="course-actions">
           <button @click="onEdit(c)" class="edit-btn" title="Edit course">
@@ -80,6 +119,13 @@ async function onDelete(course: Course) {
               <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"></path>
             </svg>
             Edit
+          </button>
+          <button @click="onManageStudents(c)" class="students-btn" title="Manage students">
+            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"/>
+              <circle cx="9" cy="7" r="4"/>
+            </svg>
+            Students
           </button>
           <button @click="onDelete(c)" class="delete-btn" title="Delete course">
             <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
@@ -110,6 +156,12 @@ async function onDelete(course: Course) {
     :course="editingCourse"
     v-model:show="showEditModal"
     @save="onSave"
+  />
+
+  <CourseStudentsModal
+    :course="studentsCourse"
+    v-model:show="showStudentsModal"
+    @save="onSaveStudents"
   />
 </template>
 
@@ -189,6 +241,16 @@ async function onDelete(course: Course) {
 .delete-btn:hover {
   background: #fecaca;
   color: #b91c1c;
+}
+
+.students-btn {
+  background: #eef2ff;
+  color: #3730a3;
+}
+
+.students-btn:hover {
+  background: #e0e7ff;
+  color: #312e81;
 }
 
 .active {

--- a/attendnow/src/components/NavBar.vue
+++ b/attendnow/src/components/NavBar.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
 import { RouterLink } from "vue-router";
 import logo from "../assets/logo.png";
+import UserMenu from "./UserMenu.vue";
 
 const emit = defineEmits<{ (e: 'open-auth', mode: 'signin' | 'signup'): void }>()
-const onSignIn = () => emit('open-auth', 'signin')
-const onSignUp = () => emit('open-auth', 'signup')
+const forwardOpen = (mode: 'signin' | 'signup') => emit('open-auth', mode)
 </script>
 
 <template>
@@ -20,8 +20,7 @@ const onSignUp = () => emit('open-auth', 'signup')
       <RouterLink to="/dashboard" class="link">Dashboard</RouterLink>
     </div>
     <div class="right">
-      <button class="ghost" @click="onSignIn">Sign in</button>
-      <button class="solid" @click="onSignUp">Sign up</button>
+      <UserMenu @open-auth="forwardOpen" />
     </div>
   </nav>
 </template>

--- a/attendnow/src/components/UserMenu.vue
+++ b/attendnow/src/components/UserMenu.vue
@@ -1,0 +1,80 @@
+<script setup lang="ts">
+import { ref, onMounted, onUnmounted, computed } from 'vue'
+import { useAuth, signOut } from '../lib/useAuth'
+
+const emit = defineEmits<{ (e: 'open-auth', mode: 'signin' | 'signup'): void }>()
+
+const { user } = useAuth()
+const open = ref(false)
+const root = ref<HTMLElement | null>(null)
+
+const initial = computed(() => {
+  const u = user.value
+  if (!u) return ''
+  const name = (u.displayName || u.email || '').trim()
+  return name ? name.charAt(0).toUpperCase() : ''
+})
+
+function toggle() { open.value = !open.value }
+function close() { open.value = false }
+function onSignIn() { emit('open-auth', 'signin') }
+function onSignUp() { emit('open-auth', 'signup') }
+async function onSignOut() { await signOut(); close() }
+
+function handleClickOutside(e: MouseEvent) {
+  if (!root.value) return
+  if (!root.value.contains(e.target as Node)) close()
+}
+
+onMounted(() => {
+  document.addEventListener('click', handleClickOutside)
+})
+onUnmounted(() => {
+  document.removeEventListener('click', handleClickOutside)
+})
+</script>
+
+<template>
+  <div class="user-menu" ref="root">
+    <template v-if="user">
+      <button class="avatar" @click="toggle" :aria-expanded="open">
+        <span class="initial">{{ initial }}</span>
+      </button>
+      <div v-if="open" class="dropdown">
+        <div class="info">
+          <div class="name">{{ user?.displayName || 'Account' }}</div>
+          <div class="email">{{ user?.email }}</div>
+        </div>
+        <button class="item" @click="onSignOut">Sign out</button>
+      </div>
+    </template>
+    <template v-else>
+      <button class="ghost" @click="onSignIn">Sign in</button>
+      <button class="solid" @click="onSignUp">Sign up</button>
+    </template>
+  </div>
+  
+</template>
+
+<style scoped>
+.user-menu { position: relative; display: inline-flex; align-items: center; gap: .5rem; }
+.avatar { width: 34px; height: 34px; border-radius: 50%; border: 1px solid rgba(255,255,255,0.2); background: #0b0d10; color:#e5e7eb; display:flex; align-items:center; justify-content:center; cursor:pointer; }
+.initial { font-weight: 600; }
+.dropdown { position: absolute; right: 0; top: calc(100% + 6px); min-width: 200px; background:#121418; border:1px solid rgba(255,255,255,0.12); border-radius:8px; box-shadow: 0 10px 30px rgba(0,0,0,0.35); padding:.4rem; z-index: 50; }
+.info { padding:.25rem .5rem .5rem; border-bottom:1px solid rgba(255,255,255,0.08); margin-bottom:.25rem; }
+.name { color:#e5e7eb; font-weight:600; font-size:.95rem; }
+.email { color:#9ca3af; font-size:.85rem; }
+.item { width:100%; text-align:left; background:transparent; border:none; color:#e5e7eb; padding:.45rem .5rem; border-radius:6px; cursor:pointer; }
+.item:hover { background: rgba(255,255,255,0.06); }
+.ghost { background: transparent; color:#e5e7eb; border:1px solid rgba(255,255,255,0.2); padding:.4rem .6rem; border-radius:8px; cursor:pointer; }
+.ghost:hover { background: rgba(255,255,255,0.06); }
+.solid { background:#8ab4ff; color:#0b0d10; border:none; padding:.45rem .7rem; border-radius:8px; cursor:pointer; font-weight:600; }
+.solid:hover { filter: brightness(1.05); }
+@media (prefers-color-scheme: light) {
+  .dropdown { background: #fff; border-color:#d1d5db; }
+  .avatar { background:#fff; color:#111; border-color:#d1d5db; }
+  .ghost { color:#111; border-color:#d1d5db; }
+  .ghost:hover { background:#f3f4f6; }
+}
+</style>
+

--- a/attendnow/src/lib/firebase.ts
+++ b/attendnow/src/lib/firebase.ts
@@ -1,5 +1,6 @@
 import { initializeApp } from "firebase/app";
 import { getFirestore } from "firebase/firestore";
+import { getAuth } from "firebase/auth";
 // (Optional) Analytics: only works in browsers with HTTPS and proper setup
 import { getAnalytics, isSupported } from "firebase/analytics";
 
@@ -14,5 +15,6 @@ const firebaseConfig = {
 
 export const app = initializeApp(firebaseConfig);
 export const db = getFirestore(app);
+export const auth = getAuth(app);
 
 export const analyticsPromise = isSupported().then((ok) => (ok ? getAnalytics(app) : null));

--- a/attendnow/src/lib/useAuth.ts
+++ b/attendnow/src/lib/useAuth.ts
@@ -1,0 +1,80 @@
+import { ref } from "vue";
+import { auth, db } from "./firebase";
+import {
+  onAuthStateChanged,
+  signInWithEmailAndPassword,
+  createUserWithEmailAndPassword,
+  updateProfile,
+  signOut as fbSignOut,
+  type User,
+} from "firebase/auth";
+import { doc, getDoc, setDoc, serverTimestamp } from "firebase/firestore";
+
+const user = ref<User | null>(auth.currentUser);
+const loading = ref<boolean>(true);
+const error = ref<string | null>(null);
+
+// Subscribe once at module load to keep user state in sync
+onAuthStateChanged(auth, async (u) => {
+  user.value = u;
+  loading.value = false;
+});
+
+async function ensureInstructorProfile(u: User, name?: string) {
+  try {
+    const ref = doc(db, "instructors", u.uid);
+    const snap = await getDoc(ref);
+    if (!snap.exists()) {
+      await setDoc(ref, {
+        uid: u.uid,
+        name: name || u.displayName || "",
+        email: u.email,
+        role: "instructor",
+        createdAt: serverTimestamp(),
+      });
+    }
+  } catch (e) {
+    // Non-fatal for app flow; keep silent to avoid blocking auth
+    console.warn("[auth] ensureInstructorProfile warning:", e);
+  }
+}
+
+export async function signIn(email: string, password: string) {
+  error.value = null;
+  try {
+    const cred = await signInWithEmailAndPassword(auth, email, password);
+    return cred;
+  } catch (e: any) {
+    error.value = e?.message ?? "Failed to sign in";
+    throw e;
+  }
+}
+
+export async function signUp(name: string, email: string, password: string) {
+  error.value = null;
+  try {
+    const cred = await createUserWithEmailAndPassword(auth, email, password);
+    if (name) {
+      try {
+        await updateProfile(cred.user, { displayName: name });
+      } catch (e) {
+        console.warn("[auth] updateProfile warning:", e);
+      }
+    }
+    await ensureInstructorProfile(cred.user, name);
+    return cred;
+  } catch (e: any) {
+    error.value = e?.message ?? "Failed to sign up";
+    throw e;
+  }
+}
+
+export async function signOut() {
+  error.value = null;
+  await fbSignOut(auth);
+}
+
+export function useAuth() {
+  return { user, loading, error, signIn, signUp, signOut };
+}
+

--- a/attendnow/src/views/HomeView.vue
+++ b/attendnow/src/views/HomeView.vue
@@ -31,7 +31,7 @@ import { RouterLink } from "vue-router";
     <section class="card">
       <h2>Data Model (starter)</h2>
       <p><strong>instructors</strong>: { instructorId, name, email }</p>
-      <p><strong>courses</strong>: { name, code, semester, students[], instructorId, activeCheckIn }</p>
+      <p><strong>courses</strong>: { name, code, semester, students_list: [{ email, name }], instructorId, activeCheckIn }</p>
       <p><strong>activeCheckIn</strong>: null or { id, passcode, startedAt, expiresAt, qrUrl? }</p>
     </section>
 


### PR DESCRIPTION
# Changelog

0.1.0 — Auth (2025-10-30)
- Instructor sign in/up/out via Firebase Auth.
- NavBar avatar with initial and Sign out dropdown.
- Courses filtered by signed-in instructor.

### Added
- Firebase Auth integration:
  - Exported `auth` from `src/lib/firebase.ts`.
  - New `src/lib/useAuth.ts` composable with `user`, `loading`, `error` and `signIn`, `signUp`, `signOut`.
  - On signup, sets `displayName` and ensures `instructors/{uid}` doc with `role: "instructor"`.
- Auth UI wiring:
  - `src/components/AuthModal.vue` calls `signIn`/`signUp`, shows loading and error states.

### Changed
- Courses now load only for the signed-in instructor:
  - `src/components/CourseList.vue` uses `useAuth().user?.uid` and resubscribes when auth changes.