### PR TITLE
Add authentication guards and restrict student access

### DIFF
--- a/attendnow/src/App.vue
+++ b/attendnow/src/App.vue
@@ -1,22 +1,44 @@
 <template>
   <div class="app-container">
     <NavBar @open-auth="onOpenAuth" />
-    <RouterView />
+    <RouterView @open-auth="onOpenAuth" />
     <AuthModal v-model:show="showAuth" :mode="authMode" />
   </div>
-  
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue'
-import { RouterView } from "vue-router";
+import { ref, watch } from 'vue'
+import { RouterView, useRoute, useRouter } from "vue-router";
 import NavBar from "./components/NavBar.vue";
 import AuthModal from "./components/AuthModal.vue";
+import { useAuth } from "./lib/useAuth";
 
 type Mode = 'signin' | 'signup'
 const showAuth = ref(false)
 const authMode = ref<Mode>('signin')
-function onOpenAuth(mode: Mode) { authMode.value = mode; showAuth.value = true }
+const route = useRoute()
+const router = useRouter()
+const { user } = useAuth()
+
+function onOpenAuth(mode: Mode) { 
+  authMode.value = mode
+  showAuth.value = true 
+}
+
+// Watch for route query params to trigger auth dialog
+watch(() => route.query.showAuth, (showAuthQuery) => {
+  if (showAuthQuery === 'signup' || showAuthQuery === 'signin') {
+    onOpenAuth(showAuthQuery as Mode)
+  }
+}, { immediate: true })
+
+// After successful auth, redirect to intended page
+watch([showAuth, user], ([isOpen, currentUser]) => {
+  if (!isOpen && currentUser && route.query.redirect) {
+    const redirect = route.query.redirect as string
+    router.push(redirect)
+  }
+})
 </script>
 
 <style scoped>

--- a/attendnow/src/components/NavBar.vue
+++ b/attendnow/src/components/NavBar.vue
@@ -2,6 +2,9 @@
 import { RouterLink } from "vue-router";
 import logo from "../assets/logo.png";
 import UserMenu from "./UserMenu.vue";
+import { useAuth } from "../lib/useAuth";
+
+const { user } = useAuth();
 
 const emit = defineEmits<{ (e: 'open-auth', mode: 'signin' | 'signup'): void }>()
 const forwardOpen = (mode: 'signin' | 'signup') => emit('open-auth', mode)
@@ -17,10 +20,10 @@ const forwardOpen = (mode: 'signin' | 'signup') => emit('open-auth', mode)
     </div>
     <div class="center">
       <RouterLink to="/" class="link">Home</RouterLink>
-      <RouterLink to="/dashboard" class="link">Dashboard</RouterLink>
-      <RouterLink to="/snapshot" class="link">Today's Snapshot</RouterLink>
-      <RouterLink to="/create" class="link">Create Course</RouterLink>
-      <RouterLink to="/studentCourseList" class="link">Student Courses</RouterLink>
+      <RouterLink v-if="user" to="/dashboard" class="link">Dashboard</RouterLink>
+      <RouterLink v-if="user" to="/snapshot" class="link">Today's Snapshot</RouterLink>
+      <RouterLink v-if="user" to="/create" class="link">Create Course</RouterLink>
+      <!-- Removed Student Courses link -->
     </div>
     <div class="right">
       <UserMenu @open-auth="forwardOpen" />

--- a/attendnow/src/router.ts
+++ b/attendnow/src/router.ts
@@ -1,13 +1,44 @@
 import { createRouter, createWebHistory, type RouteRecordRaw } from "vue-router";
+import { useAuth } from "./lib/useAuth";
 
 const routes: RouteRecordRaw[] = [
-  { path: "/", name: "home", component: () => import("./views/HomeView.vue") },
-  { path: "/dashboard", name: "dashboard", component: () => import("./views/DashboardView.vue") },
-  { path: "/snapshot", name: "snapshot", component: () => import("./views/SnapshotView.vue") },
-  { path: "/course/:courseId/attendance", name: "attendance-history", component: () => import("./views/AttendanceHistoryView.vue") },
-  { path: "/create", name: "create", component: () => import("./views/CreationView.vue") },
-  { path: "/studentCourseList", name: "studentCourseList", component: () => import("./views/StudentCourseList.vue") },
-  { path: "/checkins/:checkinId", name: "studentCheckInForm", component: () => import("./views/StudentCheckInForm.vue") },
+  { 
+    path: "/", 
+    name: "home", 
+    component: () => import("./views/HomeView.vue"),
+    meta: { requiresAuth: false }
+  },
+  { 
+    path: "/checkin/:id", // Make :id required (removed the ?)
+    name: "checkin", 
+    component: () => import("./views/StudentCheckInForm.vue"),
+    meta: { requiresAuth: false }
+  },
+  { 
+    path: "/dashboard", 
+    name: "dashboard", 
+    component: () => import("./views/DashboardView.vue"),
+    meta: { requiresAuth: true }
+  },
+  { 
+    path: "/create", 
+    name: "create", 
+    component: () => import("./views/CreationView.vue"),
+    meta: { requiresAuth: true }
+  },
+  { 
+    path: "/snapshot", 
+    name: "snapshot", 
+    component: () => import("./views/SnapshotView.vue"),
+    meta: { requiresAuth: true }
+  },
+  { 
+    path: "/course/:courseId/attendance", 
+    name: "attendance-history", 
+    component: () => import("./views/AttendanceHistoryView.vue"),
+    meta: { requiresAuth: true }
+  }
+  // Removed studentCourseList route
 ];
 
 export const router = createRouter({
@@ -16,6 +47,27 @@ export const router = createRouter({
   scrollBehavior() {
     return { top: 0 };
   },
+});
+
+// Navigation guard to protect routes
+router.beforeEach((to, from, next) => {
+  const { user } = useAuth();
+  const requiresAuth = to.meta.requiresAuth;
+  
+  if (requiresAuth && !user.value) {
+    // User is not authenticated but route requires auth
+    // Redirect to home and trigger signup dialog
+    next({
+      name: 'home',
+      query: { 
+        redirect: to.fullPath, 
+        showAuth: 'signup' 
+      }
+    });
+  } else {
+    // User is authenticated or route doesn't require auth
+    next();
+  }
 });
 
 export default router;

--- a/attendnow/src/views/HomeView.vue
+++ b/attendnow/src/views/HomeView.vue
@@ -1,5 +1,18 @@
 <script setup lang="ts">
 import { RouterLink } from "vue-router";
+import { useAuth } from "../lib/useAuth";
+
+const { user } = useAuth();
+
+// Emit event to parent
+const emit = defineEmits<{ (e: 'open-auth', mode: 'signin' | 'signup'): void }>();
+
+function handleDashboardClick(event: Event) {
+  if (!user.value) {
+    event.preventDefault();
+    emit('open-auth', 'signup');
+  }
+}
 </script>
 
 <template>
@@ -7,7 +20,13 @@ import { RouterLink } from "vue-router";
     <section class="hero">
       <h1>AttendNow</h1>
       <p class="tag">Fast, reliable attendance and check-ins for courses.</p>
-      <RouterLink class="cta" to="/dashboard">Go to Dashboard →</RouterLink>
+      <RouterLink 
+        class="cta" 
+        to="/dashboard"
+        @click="handleDashboardClick"
+      >
+        Go to Dashboard →
+      </RouterLink>
     </section>
 
     <section class="card">
@@ -22,7 +41,7 @@ import { RouterLink } from "vue-router";
     <section class="card">
       <h2>How It Works</h2>
       <ol>
-        <li>Instructor opens the Dashboard and clicks “Start check-in”.</li>
+        <li>Instructor opens the Dashboard and clicks "Start check-in".</li>
         <li>A short passcode is generated and shown to students (QR coming soon).</li>
         <li>Students scan or enter the code to mark attendance.</li>
       </ol>


### PR DESCRIPTION
- Implement route-level authentication guards using meta.requiresAuth
- Make Home and CheckIn routes public (no auth required)
- Protect Dashboard, Create, Snapshot, and Attendance routes
- Open signup dialog when unauthenticated users try to access protected routes
- Hide Dashboard, Snapshot, and Create Course nav links for unauthenticated users
- Redirect to intended destination after successful authentication
- Make checkin route require ID parameter (students access via direct link only)
- Remove student course list route to prevent browsing all courses
- Remove Student Courses link from navbar